### PR TITLE
Trim spaces before matching keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # will have compiled files and executables
 debug/
 target/
+data/
 
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html

--- a/scripts/pull-all.sh
+++ b/scripts/pull-all.sh
@@ -33,7 +33,7 @@ function pull_cards() {
     packs=$(cat $VEGA_DATA/packs.json)
 
     while read -r id; do
-        echo -n "[$index/$count] VagaPulling cards for pack '$id'..."
+        echo -n "[$index/$count] VegaPulling cards for pack '$id'..."
         if ! ./target/release/vegapull --language $LANGUAGE cards "$id" > "$VEGA_DATA/cards_$id.json"; then
             echo "Failure"
             echo "Failed to pull cards using vegapull. Aborted" >&2

--- a/src/card/attribute.rs
+++ b/src/card/attribute.rs
@@ -14,7 +14,7 @@ pub enum CardAttribute {
 
 impl CardAttribute {
     pub fn parse(localizer: &Localizer, value: &str) -> Result<CardAttribute> {
-        match localizer.match_attribute(value) {
+        match localizer.match_attribute(value.trim()) {
             Some(key) => Ok(Self::from_str(&key)?),
             None => bail!("Failed to match attribute `{}`", value),
         }

--- a/src/card/category.rs
+++ b/src/card/category.rs
@@ -14,7 +14,7 @@ pub enum CardCategory {
 
 impl CardCategory {
     pub fn parse(localizer: &Localizer, value: &str) -> Result<CardCategory> {
-        match localizer.match_category(value) {
+        match localizer.match_category(value.trim()) {
             Some(key) => Ok(Self::from_str(&key)?),
             None => bail!("Failed to match category `{}`", value),
         }

--- a/src/card/color.rs
+++ b/src/card/color.rs
@@ -15,7 +15,7 @@ pub enum CardColor {
 
 impl CardColor {
     pub fn parse(localizer: &Localizer, value: &str) -> Result<CardColor> {
-        match localizer.match_color(value) {
+        match localizer.match_color(value.trim()) {
             Some(key) => Ok(Self::from_str(&key)?),
             None => bail!("Failed to match color `{}`", value),
         }

--- a/src/scraper.rs
+++ b/src/scraper.rs
@@ -56,7 +56,7 @@ impl<'a> OpTcgScraper<'a> {
                         packs.push(pack);
                     }
                 }
-                Err(e) => bail!("failed to scrap data about packs: {}", e),
+                Err(e) => bail!("failed to scrape data about packs: {}", e),
             }
         }
 
@@ -102,7 +102,7 @@ impl<'a> OpTcgScraper<'a> {
                     cards.push(card);
                 }
                 Err(e) => {
-                    bail!("failed to scrap data about card `{}`: {}", &card_id, e)
+                    bail!("failed to scrape data about card `{}`: {}", &card_id, e)
                 }
             };
         }


### PR DESCRIPTION
## The problem

ran into 
```
➜ bash scripts/pull-all.sh
Created dir: data/english

VegaPulling the list of packs (english)...
Successfully pulled 44 packs!

[1/44] VagaPulling cards for pack '569301'... OK
[2/44] VagaPulling cards for pack '569202'... OK
[3/44] VagaPulling cards for pack '569201'... OK
[4/44] VagaPulling cards for pack '569112'...[2025-08-18T15:40:46Z ERROR vegapull] failed to scrap data about card `OP12-055`: Failed to match attribute `Slash `
Failure
Failed to pull cards using vegapull. Aborted
```

## Changes
- `.trim()` the parsed value before matching
- add `data/` to gitignore
- minor spellings

## Validation
switched `LANGUAGE="english"`
```
➜ bash scripts/pull-all.sh
The data/english is about to be wiped to hold the new data, do you want to proceed? (y/N) y
Created dir: data/english

VegaPulling the list of packs (english)...
Successfully pulled 44 packs!

[1/44] VegaPulling cards for pack '569301'... OK
...brevity
[44/44] VegaPulling cards for pack '569801'... OK
Successfully download data for 45 packs!
```
